### PR TITLE
Typo in Matrix Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ This repository will be extended as more functions are added to the [JuliaMatlab
 
 Generation of a Square Matrix using the `randn()` function and `rand()`.
 
- * MATLAB Code - `mA = randn(matrixSize, matrixSize)`, `mB = randn(matrixSize, matrixSize)`.
- * Julia Code - `mA = randn(matrixSize, matrixSize)`, `mB = randn(matrixSize, matrixSize)`.
+ * MATLAB Code - `mA = randn(matrixSize, matrixSize)`, `mB = rand(matrixSize, matrixSize)`.
+ * Julia Code - `mA = randn(matrixSize, matrixSize)`, `mB = rand(matrixSize, matrixSize)`.
 
 ![Matrix Generation][01]
 


### PR DESCRIPTION
`randn` was written both times for `mA` and `mB`.  Perhaps `mB` should refer to `rand` instead of `randn`.